### PR TITLE
Put non-set-cookie events behind a flag to save on bandwidth.

### DIFF
--- a/lib/cookiemonster.js
+++ b/lib/cookiemonster.js
@@ -25,14 +25,6 @@ let simplePrefs = require("simple-prefs").prefs;
 const kSTUDY_NAME = "cookiemonster";
 exports.kSTUDY_NAME = kSTUDY_NAME;
 
-//const kPULSE_INTERVAL = 24 * 60 * 60 * 1000; // One day in milliseconds
-const kPULSE_INTERVAL = 60 * 1000; // One day in milliseconds
-const kSTUDY_DURATION = 7 * kPULSE_INTERVAL; // One week
-
-const kUPLOAD_URL =
-  "https://testpilot.mozillalabs.com/submit/testpilot_micropilot_" +
-  kSTUDY_NAME;
-
 const kCM_VERSION = 1;
 
 /*
@@ -135,9 +127,6 @@ const kPrefs = [
 ]
 
 let micropilot = require("micropilot");
-let fuse = micropilot.Fuse;
-let monitor = require("micropilot").Micropilot('cookiemonster').start();
-exports.monitor = monitor;
 
 let self = this;
 
@@ -413,6 +402,7 @@ function recordMetadata() {
                         });
     });
 }
+exports.recordMetadata = recordMetadata;
 
 /**
  * Check channel to see if it is part of a private browsing window

--- a/lib/cookiemonster.js
+++ b/lib/cookiemonster.js
@@ -23,6 +23,8 @@ let cookiePermSvc = Cc["@mozilla.org/cookie/permission;1"]
 let simplePrefs = require("simple-prefs").prefs;
 
 const kSTUDY_NAME = "cookiemonster";
+exports.kSTUDY_NAME = kSTUDY_NAME;
+
 //const kPULSE_INTERVAL = 24 * 60 * 60 * 1000; // One day in milliseconds
 const kPULSE_INTERVAL = 60 * 1000; // One day in milliseconds
 const kSTUDY_DURATION = 7 * kPULSE_INTERVAL; // One week
@@ -374,11 +376,16 @@ function recordEvent(event) {
   events.emit(kSTUDY_NAME, {subject: null, data: eventStr});
 }
 
-// Register all observer event handlers
-events.on("http-on-modify-request", onModifyRequest, false);
+// Register all observer event handlers. onExamineResponse is for Set-Cookie
+// events, the most important type.
 events.on("http-on-examine-response", onExamineResponse, false);
-events.on("quit-application", onQuitApplication, false);
-events.on("cookie-changed", onCookieChanged, false);
+
+// Register the rest of the handlers, if we aren't bandwidth-constrained.
+if (simplePrefs.enable_all_events) {
+  events.on("http-on-modify-request", onModifyRequest, false);
+  events.on("quit-application", onQuitApplication, false);
+  events.on("cookie-changed", onCookieChanged, false);
+}
 
 // We only export this for testing
 // Return a promise that resolves when all of the prefs are recorded.
@@ -406,40 +413,6 @@ function recordMetadata() {
                         });
     });
 }
-
-/**
- * Schedule data upload every 24 hours
- * @returns void
- **/
-function scheduleUpload() {
-  if (!storage.lastUpload) {
-    storage.lastUpload = Date.now();
-  }
-
-  let simulate = simplePrefs.enable_reporting;
-  // Write cookiemonster collected data to the MP study.
-  fuse({ start: storage.lastUpload,
-         duration: kSTUDY_DURATION,
-         pulseinterval: kPULSE_INTERVAL,
-         pulsefn: function _upload() {
-           // Record any metadata to accompany this upload event
-           recordMetadata().
-           // Upload the collected data
-           then(function() {
-             storage.lastUpload = Date.now();
-             return monitor.upload(kUPLOAD_URL, {simulate: fakeUpload});
-           }).
-           // Clear the monitor
-           then(function _clear(response) {
-             console.log("upload response", JSON.stringify(response));
-             // return monitor.clear();
-           });
-         },
-         resolve_this: self
-       });
-}
-
-scheduleUpload();
 
 /**
  * Check channel to see if it is part of a private browsing window

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,9 +1,44 @@
 "use strict";
 
 let cookiemonster = require("./cookiemonster");
+let kSTUDY_NAME = cookiemonster.kSTUDY_NAME;
 
 let micropilot = require("micropilot");
 let fuse = micropilot.Fuse;
-let monitor = require("micropilot").Micropilot('cookiemonster').start();
+let monitor = require("micropilot").Micropilot(kSTUDY_NAME).start();
 exports.monitor = monitor;
-monitor.watch("cookiemonster") ;
+monitor.watch(kSTUDY_NAME);
+
+/**
+ * Schedule data upload every 24 hours
+ * @returns void
+ **/
+function scheduleUpload() {
+  if (!storage.lastUpload) {
+    storage.lastUpload = Date.now();
+  }
+
+  let simulate = simplePrefs.enable_reporting;
+  // Write cookiemonster collected data to the MP study.
+  fuse({ start: storage.lastUpload,
+         duration: kSTUDY_DURATION,
+         pulseinterval: kPULSE_INTERVAL,
+         pulsefn: function _upload() {
+           // Record any metadata to accompany this upload event
+           recordMetadata().
+           // Upload the collected data
+           then(function() {
+             storage.lastUpload = Date.now();
+             return monitor.upload(kUPLOAD_URL, {simulate: fakeUpload});
+           }).
+           // Clear the monitor
+           then(function _clear(response) {
+             console.log("upload response", JSON.stringify(response));
+             // return monitor.clear();
+           });
+         },
+         resolve_this: self
+       });
+}
+
+scheduleUpload();

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,28 @@
 "use strict";
 
+// Other people's stuff
+let { storage } = require("simple-storage");
+let simplePrefs = require("simple-prefs").prefs;
+let micropilot = require("micropilot");
+
+// Our stuff
+let self = this;
 let cookiemonster = require("./cookiemonster");
 let kSTUDY_NAME = cookiemonster.kSTUDY_NAME;
 
-let micropilot = require("micropilot");
+// Timers and constants for uploading study data
 let fuse = micropilot.Fuse;
 let monitor = require("micropilot").Micropilot(kSTUDY_NAME).start();
-exports.monitor = monitor;
-monitor.watch(kSTUDY_NAME);
+const kUPLOAD_URL =
+  "https://testpilot.mozillalabs.com/submit/testpilot_micropilot_" +
+  kSTUDY_NAME;
+
+//const kPULSE_INTERVAL = 24 * 60 * 60 * 1000; // One day in milliseconds
+const kPULSE_INTERVAL = 60 * 1000; // One day in milliseconds
+const kSTUDY_DURATION = 7 * kPULSE_INTERVAL; // One week
+
+// Watch events that are associated with cookiemonster
+monitor.watch([kSTUDY_NAME]);
 
 /**
  * Schedule data upload every 24 hours
@@ -25,7 +40,7 @@ function scheduleUpload() {
          pulseinterval: kPULSE_INTERVAL,
          pulsefn: function _upload() {
            // Record any metadata to accompany this upload event
-           recordMetadata().
+           cookiemonster.recordMetadata().
            // Upload the collected data
            then(function() {
              storage.lastUpload = Date.now();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
       "title": "Report metrics",
       "name": "enable_reporting",
       "value": false
+    },
+    {
+      "type": "bool",
+      "title": "Enable all events",
+      "name": "enable_all_events",
+      "value": true
     }
   ],
   "volo": {


### PR DESCRIPTION
Also fix bug where monitor.watch() expects an array. I gotta go to lunch too, will call you when I get back.
